### PR TITLE
fix circleci build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,18 +9,18 @@ jobs:
       - run: sudo composer self-update
       - restore_cache:
           keys:
-            - composer-v1-{{ checksum "composer.lock" }}
+            - composer-v1-{{ checksum "composer.json" }}
             - composer-v1-
-      - run: composer install --prefer-dist --optimize-autoloader --no-progress --no-interaction
+      - run: composer update --prefer-dist --optimize-autoloader --no-progress --no-interaction
       - save_cache:
-          key: composer-v1-{{ checksum "composer.lock" }}
+          key: composer-v1-{{ checksum "composer.json" }}
           paths:
             - vendor
       - run: vendor/bin/phpunit --colors=never --log-junit results.xml --coverage-html coverage
       - run: vendor/bin/php-cs-fixer fix -v --dry-run --using-cache=no
       - run: vendor/bin/phpstan analyse --no-progress
       - store_artifacts:
-          path: build/coverage
+          path: coverage
           prefix: coverage
       - store_test_results:
           path: results.xml


### PR DESCRIPTION
dependency caching failed since we don't have a lock file, use the json
file instead. Also use update instead of install so we are testing
against the latest version of dependencies.

Fix coverage path